### PR TITLE
Handle many networks

### DIFF
--- a/docker-dns.py
+++ b/docker-dns.py
@@ -23,9 +23,8 @@ class DockerResolver(client.Resolver):
         self.runningContainers = {}
         for c in dockerClient.containers.list():
             containerName = c.attrs["Name"][1:]
-            containerBridge = c.attrs["NetworkSettings"]["Networks"]["bridge"]
-            containerIPv4 = containerBridge["IPAddress"]
-            self.addContainer(containerName, containerIPv4)
+            networks = c.attrs["NetworkSettings"]["Networks"] 
+            [ self.addContainer(containerName, network["IPAddress"]) for network in networks.values() ]
 
     def addContainer(self, containerName, containerIPv4):
         self.runningContainers[containerName] = containerIPv4


### PR DESCRIPTION
Hello Daniel,

I need to handle many IPv4 from many networks on which my container are. The name of each network is not known at first time and ONE container could have MANY network. Who say network, say IPv4, so each container have many IPv4.

Each container could be on different network: get them each information about this networks and get their multiple IPv4.

Example: 

```
Add  containerName => united-kingdom.c2b.site.autobiz.dev =>   172.19.0.5
Add  containerName => united-kingdom.c2b.site.autobiz.dev =>    172.28.0.6
```

This is the result after change and remove "bridge" instance to get information about all network in which containers have IPv4.